### PR TITLE
Clete AI[bot] PR: fix: Handle empty Google API group responses

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
@@ -227,8 +227,8 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClient do
 
         {:error, :invalid_response}
 
-      # This is expected if the group has no members or we're on the last page
-      :error when key == "members" ->
+      # This is expected if the group has no members/groups or we're on the last page
+      :error when key in ["members", "groups"] ->
         {:ok, [], nil}
 
       :error ->


### PR DESCRIPTION
This is a PR opened by AI tool [Clete AI](https://www.clete.ai) to implement changes: fix: Handle empty Google API group responses