### PR TITLE
Clete AI PR: Treat empty Google API group responses as invalid

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
@@ -183,7 +183,15 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClient do
     with {:ok, %Finch.Response{body: raw_body, status: 200}} <- response,
          {:ok, json_response} <- Jason.decode(raw_body),
          {:ok, list} when is_list(list) <- Map.fetch(json_response, key) do
-      {:ok, list, json_response["nextPageToken"]}
+      # An empty groups list is invalid since no organization should have zero groups
+      if key == "groups" and list == [] do
+        Logger.error("API request returned empty groups list which is invalid",
+          response: inspect(json_response)
+        )
+        {:error, :invalid_response}
+      else
+        {:ok, list, json_response["nextPageToken"]}
+      end
     else
       {:ok, %Finch.Response{status: status}} when status in 201..299 ->
         Logger.warning("API request succeeded with unexpected 2xx status #{status}",


### PR DESCRIPTION
This is a PR opened by AI tool [Clete AI](https://www.clete.ai) to implement changes: Treat empty Google API group responses as invalid