### PR TITLE
Clete AI PR: Treat empty Google API group/user responses as invalid

### DIFF
--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
@@ -115,6 +115,19 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_users_list_endpoint(bypass, 200, "invalid json")
       assert {:error, %Jason.DecodeError{data: "invalid json"}} = list_users(api_token)
     end
+
+    test "returns invalid_response when api responds with empty users list" do
+      api_token = Ecto.UUID.generate()
+      bypass = Bypass.open()
+
+      GoogleWorkspaceDirectory.mock_users_list_endpoint(
+        bypass,
+        200,
+        Jason.encode!(%{"users" => []})
+      )
+
+      assert list_users(api_token) == {:error, :invalid_response}
+    end
   end
 
   describe "list_organization_units/1" do
@@ -317,6 +330,19 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(bypass, 200, "invalid json")
       assert {:error, %Jason.DecodeError{data: "invalid json"}} = list_groups(api_token)
     end
+
+    test "returns invalid_response when api responds with empty groups list" do
+      api_token = Ecto.UUID.generate()
+      bypass = Bypass.open()
+
+      GoogleWorkspaceDirectory.mock_groups_list_endpoint(
+        bypass,
+        200,
+        Jason.encode!(%{"groups" => []})
+      )
+
+      assert list_groups(api_token) == {:error, :invalid_response}
+    end
   end
 
   describe "list_group_members/1" do
@@ -437,6 +463,21 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
 
       assert {:error, %Jason.DecodeError{data: "invalid json"}} =
                list_group_members(api_token, group_id)
+    end
+
+    test "returns empty list when api responds with empty members list" do
+      api_token = Ecto.UUID.generate()
+      group_id = Ecto.UUID.generate()
+      bypass = Bypass.open()
+
+      GoogleWorkspaceDirectory.mock_group_members_list_endpoint(
+        bypass,
+        group_id,
+        200,
+        Jason.encode!(%{"members" => []})
+      )
+
+      assert list_group_members(api_token, group_id) == {:ok, []}
     end
   end
 end

--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
@@ -40,7 +40,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => []})
+        Jason.encode!(%{"groups" => [%{"id" => "test_group", "name" => "Test Group"}]})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
@@ -52,10 +52,17 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => []})
+        Jason.encode!(%{"users" => [%{"id" => "test_user", "name" => %{"fullName" => "Test User"}, "primaryEmail" => "test@example.com", "orgUnitPath" => "/"}]})
       )
 
       GoogleWorkspaceDirectory.mock_token_endpoint(bypass)
+
+      GoogleWorkspaceDirectory.mock_group_members_list_endpoint(
+        bypass,
+        "test_group",
+        200,
+        Jason.encode!(%{"members" => []})
+      )
 
       {:ok, pid} = Task.Supervisor.start_link()
       assert execute(%{task_supervisor: pid}) == :ok
@@ -100,7 +107,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => []})
+        Jason.encode!(%{"groups" => [%{"id" => "test_group", "name" => "Test Group"}]})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
@@ -112,7 +119,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => []})
+        Jason.encode!(%{"users" => [%{"id" => "test_user", "name" => %{"fullName" => "Test User"}, "primaryEmail" => "test@example.com", "orgUnitPath" => "/"}]})
       )
 
       provider
@@ -120,6 +127,13 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
         adapter_config: Map.put(provider.adapter_config, "service_account_json_key", nil)
       )
       |> Repo.update!()
+
+      GoogleWorkspaceDirectory.mock_group_members_list_endpoint(
+        bypass,
+        "test_group",
+        200,
+        Jason.encode!(%{"members" => []})
+      )
 
       {:ok, pid} = Task.Supervisor.start_link()
       assert execute(%{task_supervisor: pid}) == :ok
@@ -398,7 +412,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => []})
+        Jason.encode!(%{"groups" => [%{"id" => "test_group", "name" => "Test Group"}]})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
@@ -414,6 +428,13 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       )
 
       GoogleWorkspaceDirectory.mock_token_endpoint(bypass)
+
+      GoogleWorkspaceDirectory.mock_group_members_list_endpoint(
+        bypass,
+        "test_group",
+        200,
+        Jason.encode!(%{"members" => []})
+      )
 
       {:ok, pid} = Task.Supervisor.start_link()
       assert execute(%{task_supervisor: pid}) == :ok
@@ -801,7 +822,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => []})
+        Jason.encode!(%{"groups" => [%{"id" => "test_group", "name" => "Test Group"}]})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
@@ -817,6 +838,13 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       )
 
       GoogleWorkspaceDirectory.mock_token_endpoint(bypass)
+
+      GoogleWorkspaceDirectory.mock_group_members_list_endpoint(
+        bypass,
+        "test_group",
+        200,
+        Jason.encode!(%{"members" => []})
+      )
 
       {:ok, pid} = Task.Supervisor.start_link()
       assert execute(%{task_supervisor: pid}) == :ok


### PR DESCRIPTION
This is a PR opened by AI tool [Clete AI](https://www.clete.ai) to implement changes: Treat empty Google API group/user responses as invalid

Here's the [detailed postmortem analysis](https://app.clete.ai/execution?exec_id=bdb23aa47b&entity_ref=user_1&no_setup_check=1)